### PR TITLE
fixed duplicate event binding in devices which supports both pointer …

### DIFF
--- a/dist/ractive-events-tap.es.js
+++ b/dist/ractive-events-tap.es.js
@@ -23,10 +23,9 @@ TapHandler.prototype = {
 			node.addEventListener( 'MSPointerDown', handleMousedown, false );
 		} else {
 			node.addEventListener( 'mousedown', handleMousedown, false );
+			// ...and touch events
+			node.addEventListener( 'touchstart', handleTouchstart, false );
 		}
-
-		// ...and touch events
-		node.addEventListener( 'touchstart', handleTouchstart, false );
 
 		// ...and random click events
 		node.addEventListener( 'click', handleRealClick, false );

--- a/dist/ractive-events-tap.umd.js
+++ b/dist/ractive-events-tap.umd.js
@@ -29,10 +29,9 @@ TapHandler.prototype = {
 			node.addEventListener( 'MSPointerDown', handleMousedown, false );
 		} else {
 			node.addEventListener( 'mousedown', handleMousedown, false );
+			// ...and touch events
+			node.addEventListener( 'touchstart', handleTouchstart, false );
 		}
-
-		// ...and touch events
-		node.addEventListener( 'touchstart', handleTouchstart, false );
 
 		// ...and random click events
 		node.addEventListener( 'click', handleRealClick, false );

--- a/src/ractive-events-tap.js
+++ b/src/ractive-events-tap.js
@@ -23,10 +23,9 @@ TapHandler.prototype = {
 			node.addEventListener( 'MSPointerDown', handleMousedown, false );
 		} else {
 			node.addEventListener( 'mousedown', handleMousedown, false );
+			// ...and touch events
+			node.addEventListener( 'touchstart', handleTouchstart, false );
 		}
-
-		// ...and touch events
-		node.addEventListener( 'touchstart', handleTouchstart, false );
 
 		// ...and random click events
 		node.addEventListener( 'click', handleRealClick, false );


### PR DESCRIPTION
**Issue Reference:**
On device which supports pointer events and touch events, the two event listener are getting bind, which is triggering event twice one event with pointer and another touch.

**How to Reproduce:**
Run Ractive component with on-tap event attached in latest chrome browser (which have window.PointerEvent object) with mobile view simulator, once click on component with on-tap event the event listener executed twice.

**Solution:**
Fixed duplicate event binding in devices which supports both pointer and touch event, skipping touch event binding in case device supports pointer event.