### PR TITLE
fixed duplicate event when browser supports pointer events

### DIFF
--- a/dist/ractive-events-tap.es.js
+++ b/dist/ractive-events-tap.es.js
@@ -160,7 +160,7 @@ TapHandler.prototype = {
 				this$1.preventMousedownEvents = false;
 			}, 400 );
 
-			if ( this$1.preventTouchEvent ) {
+			if ( !this$1.preventTouchEvent ) {
 				this$1.fire( event, x, y );
 			}
 			cancel();

--- a/dist/ractive-events-tap.es.js
+++ b/dist/ractive-events-tap.es.js
@@ -25,9 +25,9 @@ TapHandler.prototype = {
 			node.addEventListener( 'mousedown', handleMousedown, false );
 			// ...and touch events
 			node.addEventListener( 'touchstart', handleTouchstart, false );
-			// ...and random click events
-			node.addEventListener( 'click', handleRealClick, false );
 		}
+		// ...and random click events
+		node.addEventListener( 'click', handleRealClick, false );
 
 		// native buttons, and <input type='button'> elements, should fire a tap event
 		// when the space key is pressed

--- a/dist/ractive-events-tap.es.js
+++ b/dist/ractive-events-tap.es.js
@@ -10,6 +10,7 @@ function TapHandler ( node, callback ) {
 	this.callback = callback;
 
 	this.preventMousedownEvents = false;
+	this.preventTouchEvent = false;
 
 	this.bind( node );
 }
@@ -23,9 +24,9 @@ TapHandler.prototype = {
 			node.addEventListener( 'MSPointerDown', handleMousedown, false );
 		} else {
 			node.addEventListener( 'mousedown', handleMousedown, false );
-			// ...and touch events
-			node.addEventListener( 'touchstart', handleTouchstart, false );
 		}
+		// ...and touch events
+		node.addEventListener( 'touchstart', handleTouchstart, false );
 		// ...and random click events
 		node.addEventListener( 'click', handleRealClick, false );
 
@@ -71,6 +72,13 @@ TapHandler.prototype = {
 			if ( event.pointerId != pointerId ) {
 				return;
 			}
+			// for the benefit of mobile Firefox and old Android browsers, we need this absurd hack.
+			this$1.preventTouchEvent = true;
+			clearTimeout( this$1.preventTouchTimeout );
+
+			this$1.preventTouchTimeout = setTimeout( function () {
+				this$1.preventTouchEvent = false;
+			}, 400 );
 
 			this$1.fire( event, x, y );
 			cancel();
@@ -152,7 +160,9 @@ TapHandler.prototype = {
 				this$1.preventMousedownEvents = false;
 			}, 400 );
 
-			this$1.fire( event, x, y );
+			if ( this$1.preventTouchEvent ) {
+				this$1.fire( event, x, y );
+			}
 			cancel();
 		};
 

--- a/dist/ractive-events-tap.es.js
+++ b/dist/ractive-events-tap.es.js
@@ -23,12 +23,11 @@ TapHandler.prototype = {
 			node.addEventListener( 'MSPointerDown', handleMousedown, false );
 		} else {
 			node.addEventListener( 'mousedown', handleMousedown, false );
+			// ...and touch events
+			node.addEventListener( 'touchstart', handleTouchstart, false );
+			// ...and random click events
+			node.addEventListener( 'click', handleRealClick, false );
 		}
-
-		// ...and touch events
-		node.addEventListener( 'touchstart', handleTouchstart, false );
-		// ...and random click events
-		node.addEventListener( 'click', handleRealClick, false );
 
 		// native buttons, and <input type='button'> elements, should fire a tap event
 		// when the space key is pressed

--- a/dist/ractive-events-tap.umd.js
+++ b/dist/ractive-events-tap.umd.js
@@ -29,12 +29,11 @@ TapHandler.prototype = {
 			node.addEventListener( 'MSPointerDown', handleMousedown, false );
 		} else {
 			node.addEventListener( 'mousedown', handleMousedown, false );
+			// ...and touch events
+			node.addEventListener( 'touchstart', handleTouchstart, false );
+			// ...and random click events
+			node.addEventListener( 'click', handleRealClick, false );
 		}
-
-		// ...and touch events
-		node.addEventListener( 'touchstart', handleTouchstart, false );
-		// ...and random click events
-		node.addEventListener( 'click', handleRealClick, false );
 
 		// native buttons, and <input type='button'> elements, should fire a tap event
 		// when the space key is pressed

--- a/dist/ractive-events-tap.umd.js
+++ b/dist/ractive-events-tap.umd.js
@@ -31,9 +31,9 @@ TapHandler.prototype = {
 			node.addEventListener( 'mousedown', handleMousedown, false );
 			// ...and touch events
 			node.addEventListener( 'touchstart', handleTouchstart, false );
-			// ...and random click events
-			node.addEventListener( 'click', handleRealClick, false );
 		}
+		// ...and random click events
+		node.addEventListener( 'click', handleRealClick, false );
 
 		// native buttons, and <input type='button'> elements, should fire a tap event
 		// when the space key is pressed

--- a/dist/ractive-events-tap.umd.js
+++ b/dist/ractive-events-tap.umd.js
@@ -166,7 +166,7 @@ TapHandler.prototype = {
 				this$1.preventMousedownEvents = false;
 			}, 400 );
 
-			if ( this$1.preventTouchEvent ) {
+			if ( !this$1.preventTouchEvent ) {
 				this$1.fire( event, x, y );
 			}
 			cancel();

--- a/dist/ractive-events-tap.umd.js
+++ b/dist/ractive-events-tap.umd.js
@@ -16,6 +16,7 @@ function TapHandler ( node, callback ) {
 	this.callback = callback;
 
 	this.preventMousedownEvents = false;
+	this.preventTouchEvent = false;
 
 	this.bind( node );
 }
@@ -29,9 +30,9 @@ TapHandler.prototype = {
 			node.addEventListener( 'MSPointerDown', handleMousedown, false );
 		} else {
 			node.addEventListener( 'mousedown', handleMousedown, false );
-			// ...and touch events
-			node.addEventListener( 'touchstart', handleTouchstart, false );
 		}
+		// ...and touch events
+		node.addEventListener( 'touchstart', handleTouchstart, false );
 		// ...and random click events
 		node.addEventListener( 'click', handleRealClick, false );
 
@@ -77,6 +78,13 @@ TapHandler.prototype = {
 			if ( event.pointerId != pointerId ) {
 				return;
 			}
+			// for the benefit of mobile Firefox and old Android browsers, we need this absurd hack.
+			this$1.preventTouchEvent = true;
+			clearTimeout( this$1.preventTouchTimeout );
+
+			this$1.preventTouchTimeout = setTimeout( function () {
+				this$1.preventTouchEvent = false;
+			}, 400 );
 
 			this$1.fire( event, x, y );
 			cancel();
@@ -158,7 +166,9 @@ TapHandler.prototype = {
 				this$1.preventMousedownEvents = false;
 			}, 400 );
 
-			this$1.fire( event, x, y );
+			if ( this$1.preventTouchEvent ) {
+				this$1.fire( event, x, y );
+			}
 			cancel();
 		};
 

--- a/src/ractive-events-tap.js
+++ b/src/ractive-events-tap.js
@@ -156,7 +156,7 @@ TapHandler.prototype = {
 				this.preventMousedownEvents = false;
 			}, 400 );
 
-			if ( this.preventTouchEvent ) {
+			if ( !this.preventTouchEvent ) {
 				this.fire( event, x, y );
 			}
 			cancel();

--- a/src/ractive-events-tap.js
+++ b/src/ractive-events-tap.js
@@ -10,6 +10,7 @@ function TapHandler ( node, callback ) {
 	this.callback = callback;
 
 	this.preventMousedownEvents = false;
+	this.preventTouchEvent = false;
 
 	this.bind( node );
 }
@@ -23,9 +24,9 @@ TapHandler.prototype = {
 			node.addEventListener( 'MSPointerDown', handleMousedown, false );
 		} else {
 			node.addEventListener( 'mousedown', handleMousedown, false );
-			// ...and touch events
-			node.addEventListener( 'touchstart', handleTouchstart, false );
 		}
+		// ...and touch events
+		node.addEventListener( 'touchstart', handleTouchstart, false );
 		// ...and random click events
 		node.addEventListener( 'click', handleRealClick, false );
 
@@ -69,6 +70,13 @@ TapHandler.prototype = {
 			if ( event.pointerId != pointerId ) {
 				return;
 			}
+			// for the benefit of mobile Firefox and old Android browsers, we need this absurd hack.
+			this.preventTouchEvent = true;
+			clearTimeout( this.preventTouchTimeout );
+
+			this.preventTouchTimeout = setTimeout( () => {
+				this.preventTouchEvent = false;
+			}, 400 );
 
 			this.fire( event, x, y );
 			cancel();
@@ -148,7 +156,9 @@ TapHandler.prototype = {
 				this.preventMousedownEvents = false;
 			}, 400 );
 
-			this.fire( event, x, y );
+			if ( this.preventTouchEvent ) {
+				this.fire( event, x, y );
+			}
 			cancel();
 		};
 

--- a/src/ractive-events-tap.js
+++ b/src/ractive-events-tap.js
@@ -25,9 +25,9 @@ TapHandler.prototype = {
 			node.addEventListener( 'mousedown', handleMousedown, false );
 			// ...and touch events
 			node.addEventListener( 'touchstart', handleTouchstart, false );
-			// ...and random click events
-			node.addEventListener( 'click', handleRealClick, false );
 		}
+		// ...and random click events
+		node.addEventListener( 'click', handleRealClick, false );
 
 		// native buttons, and <input type='button'> elements, should fire a tap event
 		// when the space key is pressed

--- a/src/ractive-events-tap.js
+++ b/src/ractive-events-tap.js
@@ -23,12 +23,11 @@ TapHandler.prototype = {
 			node.addEventListener( 'MSPointerDown', handleMousedown, false );
 		} else {
 			node.addEventListener( 'mousedown', handleMousedown, false );
+			// ...and touch events
+			node.addEventListener( 'touchstart', handleTouchstart, false );
+			// ...and random click events
+			node.addEventListener( 'click', handleRealClick, false );
 		}
-
-		// ...and touch events
-		node.addEventListener( 'touchstart', handleTouchstart, false );
-		// ...and random click events
-		node.addEventListener( 'click', handleRealClick, false );
 
 		// native buttons, and <input type='button'> elements, should fire a tap event
 		// when the space key is pressed


### PR DESCRIPTION
In case browser supports Pointer event, we will not bind mouse, touch and click events to node, otherwise it triggers duplicate events.